### PR TITLE
Add EXCLUDE_FROM_ALL to the CMake macro mimosa_test

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,7 +1,7 @@
 add_custom_target(check)
 
 macro(mimosa_test MODULE)
-  add_executable(tst-${MODULE} ${ARGN})
+  add_executable(tst-${MODULE} EXCLUDE_FROM_ALL ${ARGN})
   target_link_libraries(tst-${MODULE} gtest_main gtest mimosa)
   add_custom_target(run-tst-${MODULE} ./tst-${MODULE} DEPENDS tst-${MODULE})
   add_dependencies(check run-tst-${MODULE})


### PR DESCRIPTION
Don't compile test if it is not needed.
