### PR TITLE
fix compilation with newer protobuf versions

### DIFF
--- a/mimosa/rpc/gen/protoc-gen-mimosa.cc
+++ b/mimosa/rpc/gen/protoc-gen-mimosa.cc
@@ -5,7 +5,11 @@
 #include <zlib.h> // For crc32
 
 #include <google/protobuf/compiler/code_generator.h>
-#if GOOGLE_PROTOBUF_VERSION >= 5030000
+#if GOOGLE_PROTOBUF_VERSION >= 6031000
+#include <google/protobuf/compiler/cpp/generator.h>
+#elif GOOGLE_PROTOBUF_VERSION >= 6030000
+#error "Incompatible version of protobuf. Please upgrade."
+#elif GOOGLE_PROTOBUF_VERSION >= 5030000
 #include <google/protobuf/compiler/cpp/cpp_generator.h>
 #else
 #include <google/protobuf/compiler/cpp/generator.h>


### PR DESCRIPTION
Hey @abique 

This is to fix [hefur#52](https://github.com/abique/hefur/issues/52).

Not sure if this is the style you'd like to go with but it fixes the header detection and adds a fail check if v30 is used:

```
[112/144] Building CXX object mimosa/mimosa/rpc/gen/CMakeFiles/protoc-gen-mimosa.dir/protoc-gen-mimosa.cc.o
FAILED: [code=1] mimosa/mimosa/rpc/gen/CMakeFiles/protoc-gen-mimosa.dir/protoc-gen-mimosa.cc.o
/home/pkgmk/work/hefur/src/hefur-a194953310c40279b4cc8e483478ccfe2cc1157f/mimosa/mimosa/rpc/gen/protoc-gen-mimosa.cc:11:2: error: #error "Incompatible version of protobuf. Please upgrade."
   11 | #error "Incompatible version of protobuf. Please upgrade."
      |  ^~~~~
```